### PR TITLE
Use NuGet/MyGet for the Sitecore and MongoDB dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ By default only Sitecore administrators can use Experience Extractor. Specific r
 Please refer to `App_Config/Include/ExperienceExtractor/ExperienceExtractor.config` for details and other configuration options.
 
 ###Building from source
-Sitecore binaries are not part of this distribution. You need to copy your own version of these to the “components” folder in the solution's root folder. NuGet package restore is used.
-
-
+The solution uses the Sitecore MyGet feed (ensure that it is added to your NuGet package sources: https://doc.sitecore.net/sitecore_experience_platform/developing/developing_with_sitecore/sitecore_public_nuget_packages_faq).
+Please make sure that the packages reference the correct version when building for a specific Sitecore version.
 
 ##How to use
 Please refer to the [Wiki](https://github.com/Sitecore/experience-extractor/wiki/) for documentation on how to use Experience Extractor and examples.

--- a/src/ExperienceExtractor.Client/ExperienceExtractor.Client.csproj
+++ b/src/ExperienceExtractor.Client/ExperienceExtractor.Client.csproj
@@ -46,26 +46,33 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Sitecore.Mvc">
-      <HintPath>..\components\Sitecore.Mvc.dll</HintPath>
+    <Reference Include="Sitecore.Mvc, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Mvc.NoReferences.8.2.161115\lib\NET452\Sitecore.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.Applications">
-      <HintPath>..\components\Sitecore.Speak.Applications.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Applications, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.Applications.NoReferences.8.2.161115\lib\NET452\Sitecore.Speak.Applications.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.Charting">
-      <HintPath>..\components\Sitecore.Speak.Charting.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Charting, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.Charting.NoReferences.8.1.160519\lib\NET452\Sitecore.Speak.Charting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.Client">
-      <HintPath>..\components\Sitecore.Speak.Client.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Client, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.Client.NoReferences.8.2.161115\lib\NET452\Sitecore.Speak.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.ItemWebApi">
-      <HintPath>..\components\Sitecore.Speak.ItemWebApi.dll</HintPath>
+    <Reference Include="Sitecore.Speak.ItemWebApi, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.ItemWebApi.NoReferences.8.2.161115\lib\NET452\Sitecore.Speak.ItemWebApi.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.Mvc">
-      <HintPath>..\components\Sitecore.Speak.Mvc.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Mvc, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.Mvc.NoReferences.8.1.160519\lib\NET452\Sitecore.Speak.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Speak.Web">
-      <HintPath>..\components\Sitecore.Speak.Web.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Web, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Speak.Web.NoReferences.8.2.161115\lib\NET452\Sitecore.Speak.Web.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/ExperienceExtractor.Client/web.config
+++ b/src/ExperienceExtractor.Client/web.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/ExperienceExtractor.Components/ExperienceExtractor.Components.csproj
+++ b/src/ExperienceExtractor.Components/ExperienceExtractor.Components.csproj
@@ -56,26 +56,33 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\components\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics">
-      <HintPath>..\components\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Aggregation">
-      <HintPath>..\components\Sitecore.Analytics.Aggregation.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Aggregation, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Aggregation.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Aggregation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model">
-      <HintPath>..\components\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Model.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Model.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics">
-      <HintPath>..\components\Sitecore.ExperienceAnalytics.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.ExperienceAnalytics.NoReferences.8.2.161115\lib\NET452\Sitecore.ExperienceAnalytics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics.Aggregation">
-      <HintPath>..\components\Sitecore.ExperienceAnalytics.Aggregation.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics.Aggregation, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.ExperienceAnalytics.Aggregation.NoReferences.8.2.161115\lib\NET452\Sitecore.ExperienceAnalytics.Aggregation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics.Api">
-      <HintPath>..\components\Sitecore.ExperienceAnalytics.Api.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics.Api, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.ExperienceAnalytics.Api.NoReferences.8.2.161115\lib\NET452\Sitecore.ExperienceAnalytics.Api.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\components\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.161115\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/ExperienceExtractor.Components/Parsing/PostProcessors/MsSqlFactory.cs
+++ b/src/ExperienceExtractor.Components/Parsing/PostProcessors/MsSqlFactory.cs
@@ -49,7 +49,7 @@ namespace ExperienceExtractor.Components.Parsing.PostProcessors
             var ssasDatabase = state.TryGet<string>("SsasDatabase");          
 
             var exporter = new SqlExporter(connectionString,
-                state.TryGet("Database", () => state.TryGet<string>("CreateDatabase")));
+                state.TryGet("Database", () => state.TryGet<string>("CreateDatabase")), state.TryGet<bool>("clearInsteadOfDropCreate"));
 
             exporter.SqlClearOptions = state.TryGet("Clear", SqlClearOptions.None);
             exporter.Rebuild = state.TryGet("Rebuild", false);

--- a/src/ExperienceExtractor.Components/packages.config
+++ b/src/ExperienceExtractor.Components/packages.config
@@ -2,4 +2,11 @@
 <packages>
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
+  <package id="Sitecore.Analytics.Aggregation.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.Aggregation.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.Api.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/ExperienceExtractor.MongoDb/ExperienceExtractor.MongoDb.csproj
+++ b/src/ExperienceExtractor.MongoDb/ExperienceExtractor.MongoDb.csproj
@@ -41,48 +41,40 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <ItemGroup Condition="'$(Configuration)'=='8.0 update 0 to 4'">
-    <Reference Include="MongoDB.Bson, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components80\MongoDB.Bson.dll</HintPath>
-    </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components80\MongoDB.Driver.dll</HintPath>
-    </Reference>
-    <Reference Include="Sitecore.Analytics.MongoDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components80\Sitecore.Analytics.MongoDB.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'!='8.0 update 0 to 4'">
-    <Reference Include="MongoDB.Bson, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\MongoDB.Bson.dll</HintPath>
-    </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\MongoDB.Driver.dll</HintPath>
-    </Reference>
-    <Reference Include="Sitecore.Analytics.MongoDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Analytics.MongoDB.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.MongoDB, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.MongoDB.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.MongoDB.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="MongoDB.Bson, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\components\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Aggregation">
-      <HintPath>..\components\Sitecore.Analytics.Aggregation.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Aggregation, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Aggregation.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Aggregation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model">
-      <HintPath>..\components\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Model.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Model.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -104,6 +96,7 @@
     <None Include="..\ExperienceExtractor\ExperienceExtractor.licenseheader">
       <Link>ExperienceExtractor.licenseheader</Link>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ExperienceExtractor\ExperienceExtractor.csproj">

--- a/src/ExperienceExtractor.MongoDb/packages.config
+++ b/src/ExperienceExtractor.MongoDb/packages.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Copyright 2015 Sitecore Corporation A/S
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file 
+except in compliance with the License. You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+-->
+<packages>
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net452" />
+  <package id="Sitecore.Analytics.Aggregation.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.MongoDB.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+</packages>

--- a/src/ExperienceExtractor.Scheduling/ExperienceExtractor.Scheduling.csproj
+++ b/src/ExperienceExtractor.Scheduling/ExperienceExtractor.Scheduling.csproj
@@ -44,13 +44,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\components\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Core.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=7.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.161115\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/ExperienceExtractor.Scheduling/packages.config
+++ b/src/ExperienceExtractor.Scheduling/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Copyright 2015 Sitecore Corporation A/S
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file 
+except in compliance with the License. You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+-->
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/src/ExperienceExtractor.Tests/ExperienceExtractor.Tests.csproj
+++ b/src/ExperienceExtractor.Tests/ExperienceExtractor.Tests.csproj
@@ -45,17 +45,17 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Sitecore.Analytics.Aggregation, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Analytics.Aggregation.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Aggregation, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Aggregation.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Aggregation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Model.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Model.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=7.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.161115\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/ExperienceExtractor.Tests/packages.config
+++ b/src/ExperienceExtractor.Tests/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Copyright 2015 Sitecore Corporation A/S
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file 
+except in compliance with the License. You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+-->
+<packages>
+  <package id="Sitecore.Analytics.Aggregation.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/src/ExperienceExtractor/ExperienceExtractor.csproj
+++ b/src/ExperienceExtractor/ExperienceExtractor.csproj
@@ -54,30 +54,37 @@
       <HintPath>..\packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics">
-      <HintPath>..\components\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Analytics.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Aggregation">
-      <HintPath>..\components\Sitecore.Analytics.Aggregation.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Aggregation, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Aggregation.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Aggregation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core">
-      <HintPath>..\components\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Core.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.DataAccess">
-      <HintPath>..\components\Sitecore.Analytics.DataAccess.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.DataAccess, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.DataAccess.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.DataAccess.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model">
-      <HintPath>..\components\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Analytics.Model.NoReferences.8.2.161115\lib\NET452\Sitecore.Analytics.Model.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics">
-      <HintPath>..\components\Sitecore.ExperienceAnalytics.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.ExperienceAnalytics.NoReferences.8.2.161115\lib\NET452\Sitecore.ExperienceAnalytics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\components\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSI">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.161115\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -85,9 +92,9 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
@@ -96,13 +103,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\components\System.Web.Http.WebHost.dll</HintPath>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/ExperienceExtractor/packages.config
+++ b/src/ExperienceExtractor/packages.config
@@ -14,6 +14,17 @@ and limitations under the License.
 -->
 <packages>
   <package id="CsvHelper" version="2.8.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="Sitecore.Analytics.Aggregation.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.DataAccess.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.161115" targetFramework="net452" developmentDependency="true" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This way, we can let NuGet do the heavy lifting and it is no longer required to copy over the assemblies from your Sitecore project to the "components" folder if you want to build the module from source.