### PR TITLE
Added option to not drop and create the database, but just remove the…

### DIFF
--- a/src/ExperienceExtractor.Components/Parsing/PostProcessors/MsSqlFactory.cs
+++ b/src/ExperienceExtractor.Components/Parsing/PostProcessors/MsSqlFactory.cs
@@ -49,7 +49,7 @@ namespace ExperienceExtractor.Components.Parsing.PostProcessors
             var ssasDatabase = state.TryGet<string>("SsasDatabase");          
 
             var exporter = new SqlExporter(connectionString,
-                state.TryGet("Database", () => state.TryGet<string>("CreateDatabase")));
+                state.TryGet("Database", () => state.TryGet<string>("CreateDatabase")), state.TryGet<bool>("clearInsteadOfDropCreate"));
 
             exporter.SqlClearOptions = state.TryGet("Clear", SqlClearOptions.None);
             exporter.Rebuild = state.TryGet("Rebuild", false);


### PR DESCRIPTION
… tables from the database (works if the database user does not have rights to drop/create databases)

For the Wiki documentation:
_If you specify `"clearInsteadOfDropCreate": true` within your mssql postprocessor, it will no longer remove and create the database. Instead, it will drop all the tables in the database and it will create the new ones.

This is useful if the DB user does not have rights to drop/create databases._